### PR TITLE
Add option to skip the encoding of the response body.

### DIFF
--- a/lib/maremma.rb
+++ b/lib/maremma.rb
@@ -229,9 +229,18 @@ module Maremma
   end
 
   def self.parse_response(string, options = {})
-    string = string.dup.encode(Encoding.find("UTF-8"), invalid: :replace,
-                                                       undef: :replace,
-                                                       replace: "?")
+    string = string.dup
+    string =
+        if options[:skip_encoding]
+            string
+        else
+            string.encode(
+                Encoding.find("UTF-8"),
+                invalid: :replace,
+                undef: :replace,
+                replace: "?"
+            )
+        end
     return string if options[:raw]
 
     from_json(string) || from_xml(string) || from_string(string)

--- a/spec/fixtures/vcr_cassettes/Maremma/get/get_utf8_bad_encoding.yml
+++ b/spec/fixtures/vcr_cassettes/Maremma/get/get_utf8_bad_encoding.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.sandbox.orcid.org/v3.0/0000-0002-5721-4355
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.9.5; +https://github.com/datacite/maremma)
+      Accept:
+      - application/json;charset=UTF-8
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 27 Oct 2021 13:46:08 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Encoding:
+      - gzip
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6a4c5e658b6919e7-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAALRVy27bMBD8FYOnFrDiWH77mqRFr0V6KnqgxbW1DUWqJKXECPJBOeTQb/CPdemnHKumW9gGLAjicGZ3uBo9M20SFBEKUA6nCIaNn1lhkI1Z6lxux62W5UpM9NPVEknXWeuafhH946g3iNtRt9PrsSbLuUtpW/1iqq2jxQMu9kIbDUzBgErAenWpEy6BwKD8aorWaTP3K4kB7lCrKAOXakGQ2y9f727uiT/RWS5huSi4o92qkLLJbDHJ0Nrd42dWclnQTbvf6Q66o+F13Bt0SEZy66JMC2+CqAOPOnGn0437AwInkmMGVIAzBZCKLkyy1RTAE4clPyimBLNih4yj3GzePs0NZtzMq6veHDBWq6UvNRWuiBXPYOtPffXLVjvX7f6/tBoTeIYlqMgr2AqK3XLHbxZvbvHqz2jKM5TzaFPHBvTt/tOwcb94paP3phkQ6Nag9fHsGVeixQlKdHTYLC8mEpPjY0Wk2qVgduX93aMdkI2//9jS1s1yq0pKGhPUM8PzdH6Cx0O6dE/xmHCj/iCOR94ZrRy9f1TOnU0M0rg3Gz/pJbSONxuoSrAOZ1xo0/jwmV6gxRs9vrM5X/ymm/Zo2P54xQL21fa5a4yKMGCBm8R3XhgZcHMfHHb0PTnpLcc8ILN+FULsKxhxciFIyYZmYQ0LE2+ARP0A80dtRIB5jQozb+m8E08OjOKyksIhXw53nOBSnczL8T3r9PHW+kxDh2AjW2Q+qI6XKGh6USU+BEOnMZ3S1K7icmZ0kYdb2SP3Dooi4ZeRqlAvhzaXep6RfxdQqnD7TC2UQDUL6JzIvSUjYgoU9AmWa4uX8exQgWQzyCY0TSnm5xesci+/mZQzBkqEx/PYt0dIAr8KLonsUjP3jr4SzlTE6pt5nr5qaEnMgikxKPEffW2JSYTS7+E8TayYAkG2i68Akr38AQAA//8DAEWCRUMUCwAA
+    http_version:
+  recorded_at: Wed, 27 Oct 2021 13:46:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/fixtures/vcr_cassettes/Maremma/get/get_utf8_skip_encoding.yml
+++ b/spec/fixtures/vcr_cassettes/Maremma/get/get_utf8_skip_encoding.yml
@@ -1,0 +1,59 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://pub.sandbox.orcid.org/v3.0/0000-0002-5721-4355
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Mozilla/5.0 (compatible; Maremma/4.9.5; +https://github.com/datacite/maremma)
+      Accept:
+      - application/json;charset=UTF-8
+      Accept-Encoding:
+      - gzip,deflate
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Wed, 27 Oct 2021 13:46:08 GMT
+      Content-Type:
+      - application/json;charset=UTF-8
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store, max-age=0, must-revalidate
+      Pragma:
+      - no-cache
+      Expires:
+      - '0'
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Frame-Options:
+      - DENY
+      X-Content-Type-Options:
+      - nosniff
+      Vary:
+      - accept-encoding
+      Content-Encoding:
+      - gzip
+      Cf-Cache-Status:
+      - DYNAMIC
+      Expect-Ct:
+      - max-age=604800, report-uri="https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct"
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 6a4c5e69ad5f1a07-EWR
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAAAAAAAAALRVy27bMBD8FYOnFrDiWH77mqRFr0V6KnqgxbW1DUWqJKXECPJBOeTQb/CPdemnHKumW9gGLAjicGZ3uBo9M20SFBEKUA6nCIaNn1lhkI1Z6lxux62W5UpM9NPVEknXWeuafhH946g3iNtRt9PrsSbLuUtpW/1iqq2jxQMu9kIbDUzBgErAenWpEy6BwKD8aorWaTP3K4kB7lCrKAOXakGQ2y9f727uiT/RWS5huSi4o92qkLLJbDHJ0Nrd42dWclnQTbvf6Q66o+F13Bt0SEZy66JMC2+CqAOPOnGn0437AwInkmMGVIAzBZCKLkyy1RTAE4clPyimBLNih4yj3GzePs0NZtzMq6veHDBWq6UvNRWuiBXPYOtPffXLVjvX7f6/tBoTeIYlqMgr2AqK3XLHbxZvbvHqz2jKM5TzaFPHBvTt/tOwcb94paP3phkQ6Nag9fHsGVeixQlKdHTYLC8mEpPjY0Wk2qVgduX93aMdkI2//9jS1s1yq0pKGhPUM8PzdH6Cx0O6dE/xmHCj/iCOR94ZrRy9f1TOnU0M0rg3Gz/pJbSONxuoSrAOZ1xo0/jwmV6gxRs9vrM5X/ymm/Zo2P54xQL21fa5a4yKMGCBm8R3XhgZcHMfHHb0PTnpLcc8ILN+FULsKxhxciFIyYZmYQ0LE2+ARP0A80dtRIB5jQozb+m8E08OjOKyksIhXw53nOBSnczL8T3r9PHW+kxDh2AjW2Q+qI6XKGh6USU+BEOnMZ3S1K7icmZ0kYdb2SP3Dooi4ZeRqlAvhzaXep6RfxdQqnD7TC2UQDUL6JzIvSUjYgoU9AmWa4uX8exQgWQzyCY0TSnm5xesci+/mZQzBkqEx/PYt0dIAr8KLonsUjP3jr4SzlTE6pt5nr5qaEnMgikxKPEffW2JSYTS7+E8TayYAkG2i68Akr38AQAA//8DAEWCRUMUCwAA
+    http_version:
+  recorded_at: Wed, 27 Oct 2021 13:46:00 GMT
+recorded_with: VCR 3.0.3

--- a/spec/maremma_spec.rb
+++ b/spec/maremma_spec.rb
@@ -92,6 +92,20 @@ describe Maremma do
       response = subject.get("https://data.crosscite.org/application/vnd.datacite.datacite+xml/10.5061/dryad.8515", headers: { "Accept-Encoding" => "gzip" })
       expect(response.body["data"]).to be_a(Hash)
     end
+
+    it "get utf8 bad encoding", vcr: true do
+      response = subject.get("https://pub.sandbox.orcid.org/v3.0/0000-0002-5721-4355", accept: "json")
+      expect(response.body["data"]).to be_a(Hash)
+      expect(response.body["data"]["person"]["name"]["given-names"]["value"]).to eq("DataC??t??")
+      expect(response.body["data"]["person"]["name"]["family-name"]["value"]).to eq("UTF8 T??st")
+    end
+
+    it "get utf8 skip encoding", vcr: true do
+      response = subject.get("https://pub.sandbox.orcid.org/v3.0/0000-0002-5721-4355", accept: "json", skip_encoding: true)
+      expect(response.body["data"]).to be_a(Hash)
+      expect(response.body["data"]["person"]["name"]["given-names"]["value"]).to eq("DataCíté")
+      expect(response.body["data"]["person"]["name"]["family-name"]["value"]).to eq("UTF8 Tést")
+    end
   end
 
   context "head" do


### PR DESCRIPTION
## Purpose
<!--- _Describe the problem or feature in addition to a link to the issues._ -->
Response bodies were automatically encoded in UTF8 and replaced characters it couldn't understand with "??".
Sometimes this encoding is not needed and the user of the library may need to opt out of that conversion. 

This came up in response to issues described in https://github.com/datacite/datacite/issues/1336

## Approach
<!--- _How does this change address the problem?_ -->
This PR allows the user to add a "skip_encoding" option that if present, signals that the response body should not be encoded.

#### Open Questions and Pre-Merge TODOs
<!--- - [ ] Use github checklists. When solved, check the box and explain the answer. -->
None
## Learning
<!--- _Describe the research stage_ -->

<!--- _Links to blog posts, patterns, libraries or addons used to solve this problem_ -->


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)

- [ ] New feature (non-breaking change which adds functionality)

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.
